### PR TITLE
Return disabled state when editor is destroyed

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1324,6 +1324,9 @@
 		}
 
 		function stateFromNamedCommand( command ) {
+			
+			if (editor.status == 'destroyed') return CKEDITOR.TRISTATE_DISABLED;
+			
 			var selection = editor.getSelection(),
 				range = selection && selection.getRanges()[ 0 ],
 				// We need to correctly update toolbar states on readOnly (#2775).


### PR DESCRIPTION
Callbacks are still firing on destroyed editors and causing errors.  Returning disabled tristate seems to prevent the errors.

<!--
🚨 If you want to submit a PR for a security vulnerability, please contact us directly
at https://ckeditor.com/contact/ instead. 🚨
-->
## What is the purpose of this pull request?

<!-- Bug fix / New feature / Typo fix / Other, please explain  -->

## Does your PR contain necessary tests?

All patches that change the editor code must include tests. You can always read more
on [PR testing](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_contributing_code.html#tests),
[how to set the testing environment](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html) and
[how to create tests](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_tests.html#creating-your-own-test)
in the official CKEditor documentation.

### This PR contains

- [ ] Unit tests
- [ ] Manual tests

## Did you follow the CKEditor 4 code style guide?

Your code should follow the guidelines from the [CKEditor 4 code style guide](https://github.com/ckeditor/ckeditor4/blob/major/dev/docs/codestyle.md) which helps keep the entire codebase consistent.

- [ ] PR is consistent with the code style guide

## What is the proposed changelog entry for this pull request?

```
* [#<ISSUE_NUMBER>](https://github.com/ckeditor/ckeditor4/issues/<ISSUE_NUMBER>): Describe the purpose of the pull request in a few simple sentences.
```

## What changes did you make?

*Give an overview…*

## Which issues does your PR resolve?

Closes #<ISSUE_NUMBER>.
<!-- Closes #<ANOTHER_ISSUE_NUMBER>. -->
